### PR TITLE
Use the official CycloneDX image for source code scanning.

### DIFF
--- a/toolkit-enablement/concert-sample/concert_data/demo_build_envs.variables
+++ b/toolkit-enablement/concert-sample/concert_data/demo_build_envs.variables
@@ -32,6 +32,7 @@ export CONCERT_URL="Your IBM Concert URL"
 export INSTANCE_ID="0000-0000-0000-0000"
 export API_KEY="Your API Key"
 export SPEC_VERSION="1.0.2"
+export CYCLONEDX_CODE_SCAN_IMAGE="ghcr.io/cyclonedx/cdxgen:master"
 
 ##
 # Application Variables

--- a/toolkit-enablement/concert-utils/helpers/create-code-cyclonedx-sbom.sh
+++ b/toolkit-enablement/concert-utils/helpers/create-code-cyclonedx-sbom.sh
@@ -47,6 +47,6 @@ done
 
 export OUTPUT_FILENAME=$outputfile 
 
-CODE_SCAN_COMMAND="code-scan --src /concert-sample --output-file ${OUTPUT_FILENAME} --cdxgen-args \"${CDXGEN_ARGS}\" "
-echo "${CONTAINER_COMMAND} ${OPTIONS} -v ${SRC_PATH}:/concert-sample -v ${OUTPUTDIR}:/toolkit-data ${CONCERT_TOOLKIT_IMAGE} bash -c ${CODE_SCAN_COMMAND}"
-${CONTAINER_COMMAND} ${OPTIONS} -v ${SRC_PATH}:/concert-sample -v ${OUTPUTDIR}:/toolkit-data ${CONCERT_TOOLKIT_IMAGE} bash -c "${CODE_SCAN_COMMAND}"
+CODE_SCAN_COMMAND="-r /app -o /toolkit-data/${OUTPUT_FILENAME} --cdxgen-args \"${CDXGEN_ARGS}\" "
+echo "${CONTAINER_COMMAND} ${OPTIONS} -v /tmp:/tmp -v ${SRC_PATH}:/app -v ${OUTPUTDIR}:/toolkit-data ${CYCLONEDX_CODE_SCAN_IMAGE} ${CODE_SCAN_COMMAND}"
+${CONTAINER_COMMAND} ${OPTIONS} -v /tmp:/tmp -v ${SRC_PATH}:/app -v ${OUTPUTDIR}:/toolkit-data ${CYCLONEDX_CODE_SCAN_IMAGE} ${CODE_SCAN_COMMAND}


### PR DESCRIPTION
The toolkit can not scan JAVA code, getting error:

```
/bin/sh: line 1: mvn: command not found

The above build errors could be due to:

1. Java version requirement: cdxgen container image bundles Java 23 with maven 3.9 which might be incompatible. Try running cdxgen with the custom JDK11-based image `ghcr.io/cyclonedx/cdxgen-java:v10`.
2. Private dependencies cannot be downloaded: Check if any additional arguments must be passed to maven and set them via MVN_ARGS environment variable.
3. Check if all required environment variables including any maven profile arguments are passed correctly to this tool.
```

The proposal is to use the official CycloneDX image for source code scanning.
Sources: https://github.com/CycloneDX/cdxgen?tab=readme-ov-file#installing